### PR TITLE
Update packages.yaml

### DIFF
--- a/spack/configs/packages.yaml
+++ b/spack/configs/packages.yaml
@@ -11,7 +11,5 @@ packages:
     require: +example +shared +static_tools
   tau:
     require:
-    - one_of:
-      - "@2.35: +comm +binutils +elf +libdwarf +libunwind +mpi +otf2 +pdt +papi +pthreads +python"
-      - "@:2.34 +binutils +elf +libdwarf +libunwind +mpi +otf2 +pdt +papi +pthreads +python"
+    - "@:2.34 +binutils +elf +libdwarf +libunwind +mpi +otf2 +pdt +papi +pthreads +python"
 


### PR DESCRIPTION
There is no TAU 2.25 in spack yet, the existing optional `one_of` spec breaks when trying to add this env.

Making this change allows the CI to create the pipeline as shown here: https://gitlab.spack.io/spack/spack-packages/-/pipelines/1129141 