### PR TITLE
Add CMake project to install configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(tools-sdk
+    LANGUAGES NONE
+    DESCRIPTION "spack configs for the tools sdk"
+    HOMEPAGE_URL tools-integration.github.io)
+
+install(FILES spack/configs/packages.yaml DESTINATION spack/configs/toolssdk)
+install(DIRECTORY spack/template DESTINATION spack/environments/toolssdk)


### PR DESCRIPTION
Adds a basic `CMakeLists.txt` to allow installation of tools sdk configs.