### PR TITLE
tau libunwind variant changed syntax

### DIFF
--- a/spack/configs/packages.yaml
+++ b/spack/configs/packages.yaml
@@ -11,7 +11,7 @@ packages:
     require: +example +shared +static_tools
   tau:
     require:
-      - +binutils +elf +libdwarf +libunwind +mpi +otf2 +pdt +papi +pthreads +python
+      - +binutils +elf +libdwarf libunwind=shared +mpi +otf2 +pdt +papi +pthreads +python
     prefer:
       - +comm
     conflict:


### PR DESCRIPTION
+libunwind now fails. It needs to be set to one of shared, static or none.