### PR TITLE
Add CDash submission for Frontier

### DIFF
--- a/scripts/ci/gitlab-ci/run.sh
+++ b/scripts/ci/gitlab-ci/run.sh
@@ -114,6 +114,9 @@ case ${STEP} in
     echo "**********Submit Begin**********"
     # Placeholder for submission to CDash or other reporting systems
     echo "Submit step - currently a placeholder"
+
+    find "${SPACK_USER_CACHE_PATH}"/reports -type f -exec curl -T {} "https://open.cdash.org/submit.php?project=TOOLS-SDK" ';'
+
     echo "**********Submit End**********"
     ;;
 


### PR DESCRIPTION
I just copy/pasted this from the dav-sdk script, but I couldn't find a description of the contents of `"${SPACK_USER_CACHE_PATH}"/reports` in the spack docs. Given the context here, I assume it's just the build logs that cdash can directly parse?